### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a Model Context Protocol (MCP) server that provides a tool for generating placeholder images from different providers.
 
+<a href="https://glama.ai/mcp/servers/pye2qsv1wz"><img width="380" height="200" src="https://glama.ai/mcp/servers/pye2qsv1wz/badge" alt="Image Placeholder Server MCP server" /></a>
+
 ## Features
 
 - Generates placeholder images from supported providers


### PR DESCRIPTION
This PR adds a badge for the [MCP Image Placeholder Server](https://glama.ai/mcp/servers/pye2qsv1wz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pye2qsv1wz"><img width="380" height="200" src="https://glama.ai/mcp/servers/pye2qsv1wz/badge" alt="Image Placeholder Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.